### PR TITLE
chore(devcontainer): add the WakaTime extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
   "workspaceFolder": "/home/vscode/app",
   "shutdownAction": "stopCompose",
   "remoteUser": "vscode",
+  "remoteEnv": {
+    "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
+  },
   "mounts": ["source=${env:HOME}/home/vscode/.ssh,target=/.ssh,type=bind,consistency=cached,readonly"],
   "features": {
     "ghcr.io/devcontainers/features/git:1": {
@@ -37,6 +40,7 @@
         "Lokalise.i18n-ally",
         "PKief.material-icon-theme",
         "Stripe.vscode-stripe",
+        "WakaTime.vscode-wakatime",
         "antfu.file-nesting",
         "bierner.github-markdown-preview",
         "bierner.markdown-mermaid",


### PR DESCRIPTION
## What
`.devcontainer/devcontainer.json` に `WakaTime.vscode-wakatime` を追加した。
あわせて \`remoteEnv\` に \`WAKATIME_API_KEY\` の受け渡しを追加した。

## Why
Dev Container を使っている全リポジトリでコーディング時間を計測できるようにするため。

## Test plan
Dev Container をリビルドして WakaTime 拡張が入ることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)